### PR TITLE
fix: configure base URL for GitHub Pages repository deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig(({ mode }) => {
   const isDev = mode === 'development';
   
   return {
+    base: isDev ? '/' : '/live-preview/',
     plugins: [vue(), tailwindcss()],
     root: '.',
     publicDir: 'public',


### PR DESCRIPTION
Configures Vite base URL to /live-preview/ for production builds while keeping development at /. Fixes Vue.js app not loading due to incorrect asset paths on GitHub Pages.